### PR TITLE
Implement forum topic routing and message logging for driver bot

### DIFF
--- a/main/admin.py
+++ b/main/admin.py
@@ -1,35 +1,47 @@
 from django.contrib import admin
-from .models import *
+from .models import Company, TeleUser, TimeOff, Category, Question, UserQuestion, BotConfig, MessageLog
 
 admin.site.site_header = "Sayram Express LLC"
 admin.site.site_title = "Sayram Express LLC Admin Page"
 
+
 @admin.register(Company)
 class CompanyAdmin(admin.ModelAdmin):
-    list_display = ('name',)
+    list_display = ('name', 'manager_group_id', 'driver_group_id')
+
 
 @admin.register(TeleUser)
 class TeleUserAdmin(admin.ModelAdmin):
-    list_display = ('first_name', 'nickname', 'truck_number', 'company',  'telegram_id')
+    list_display = ('first_name', 'nickname', 'truck_number', 'company', 'telegram_id')
 
 
 @admin.register(TimeOff)
 class TimeOffAdmin(admin.ModelAdmin):
-    list_display = ('teleuser', 'date_from', 'date_till', 'reason',  'pause_insurance', 'created_at')
+    list_display = ('teleuser', 'date_from', 'date_till', 'reason', 'pause_insurance', 'created_at')
 
 
 @admin.register(Category)
 class CategoryAdmin(admin.ModelAdmin):
-    list_display = ('name', 'responsible_chat', 'responsible_topic_id', 'id')
+    list_display = ('name', 'company', 'responsible_topic_id', 'id')
+
 
 @admin.register(Question)
 class QuestionAdmin(admin.ModelAdmin):
     list_display = ('question', 'category', 'id')
 
+
 @admin.register(UserQuestion)
 class UserQuestionAdmin(admin.ModelAdmin):
     list_display = ('username', 'created_at', 'category', 'responsible_id', 'user_id')
 
+
 @admin.register(BotConfig)
 class BotConfigAdmin(admin.ModelAdmin):
     list_display = ["id", "manager_chat_id"]
+
+
+@admin.register(MessageLog)
+class MessageLogAdmin(admin.ModelAdmin):
+    list_display = ('teleuser', 'company', 'category', 'topic_id', 'sent_at')
+    list_filter = ('company', 'category')
+    search_fields = ('teleuser__first_name', 'teleuser__nickname', 'teleuser__telegram_id')

--- a/main/migrations/0015_update_bot_schema.py
+++ b/main/migrations/0015_update_bot_schema.py
@@ -1,0 +1,83 @@
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+def assign_company_to_categories(apps, schema_editor):
+    Category = apps.get_model('main', 'Category')
+    Company = apps.get_model('main', 'Company')
+    company = Company.objects.first()
+    if not company:
+        company = Company.objects.create(name='Default Company')
+    Category.objects.filter(company__isnull=True).update(company=company)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('main', '0014_remove_userquestion_date_remove_userquestion_group_and_more'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='company',
+            name='name',
+            field=models.CharField(max_length=200),
+        ),
+        migrations.RemoveField(
+            model_name='company',
+            name='chat_id',
+        ),
+        migrations.AddField(
+            model_name='company',
+            name='driver_group_id',
+            field=models.BigIntegerField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name='company',
+            name='manager_group_id',
+            field=models.BigIntegerField(blank=True, null=True),
+        ),
+        migrations.RemoveField(
+            model_name='teleuser',
+            name='accounting_topic_id',
+        ),
+        migrations.RemoveField(
+            model_name='teleuser',
+            name='operations_topic_id',
+        ),
+        migrations.RemoveField(
+            model_name='teleuser',
+            name='safety_topic_id',
+        ),
+        migrations.RemoveField(
+            model_name='category',
+            name='responsible_chat',
+        ),
+        migrations.AddField(
+            model_name='category',
+            name='company',
+            field=models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.CASCADE, to='main.company'),
+        ),
+        migrations.CreateModel(
+            name='MessageLog',
+            fields=[
+                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('from_group_id', models.BigIntegerField()),
+                ('to_group_id', models.BigIntegerField()),
+                ('topic_id', models.BigIntegerField(blank=True, null=True)),
+                ('content_text', models.TextField(blank=True, null=True)),
+                ('content_photo', models.TextField(blank=True, null=True)),
+                ('content_voice', models.TextField(blank=True, null=True)),
+                ('sent_at', models.DateTimeField(auto_now_add=True)),
+                ('category', models.ForeignKey(null=True, on_delete=django.db.models.deletion.SET_NULL, to='main.category')),
+                ('company', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='main.company')),
+                ('teleuser', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='main.teleuser')),
+            ],
+        ),
+        migrations.RunPython(assign_company_to_categories, migrations.RunPython.noop),
+        migrations.AlterField(
+            model_name='category',
+            name='company',
+            field=models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='main.company'),
+        ),
+    ]


### PR DESCRIPTION
## Summary
- extend the data model with manager/driver group tracking and a MessageLog table for forwarded driver content
- refresh the Django admin to expose the new company fields and message history records
- rework the Aiogram bot to auto-create forum topics per category, forward messages into those threads, encode media, and persist message metadata
- add a migration that removes obsolete topic fields and aligns existing data with the new schema

## Testing
- `python manage.py makemigrations` *(fails: Django not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e60f63ead08328a1ce7133f967ed84