### PR TITLE
Add per-driver topic routing for manager groups

### DIFF
--- a/main/admin.py
+++ b/main/admin.py
@@ -1,5 +1,5 @@
 from django.contrib import admin
-from .models import Company, TeleUser, TimeOff, Category, Question, UserQuestion, BotConfig, MessageLog
+from .models import Company, TeleUser, TimeOff, Category, Question, UserQuestion, BotConfig, MessageLog, TopicMap
 
 admin.site.site_header = "Sayram Express LLC"
 admin.site.site_title = "Sayram Express LLC Admin Page"
@@ -12,7 +12,15 @@ class CompanyAdmin(admin.ModelAdmin):
 
 @admin.register(TeleUser)
 class TeleUserAdmin(admin.ModelAdmin):
-    list_display = ('first_name', 'nickname', 'truck_number', 'company', 'telegram_id')
+    list_display = (
+        'first_name',
+        'nickname',
+        'truck_number',
+        'company',
+        'telegram_id',
+        'driver_group_id',
+        'manager_group_id',
+    )
 
 
 @admin.register(TimeOff)
@@ -42,6 +50,20 @@ class BotConfigAdmin(admin.ModelAdmin):
 
 @admin.register(MessageLog)
 class MessageLogAdmin(admin.ModelAdmin):
-    list_display = ('teleuser', 'company', 'category', 'topic_id', 'sent_at')
-    list_filter = ('company', 'category')
+    list_display = (
+        'teleuser',
+        'company',
+        'category',
+        'category_name',
+        'topic_id',
+        'manager_group_id',
+        'sent_at',
+    )
+    list_filter = ('company', 'category', 'manager_group_id')
     search_fields = ('teleuser__first_name', 'teleuser__nickname', 'teleuser__telegram_id')
+
+
+@admin.register(TopicMap)
+class TopicMapAdmin(admin.ModelAdmin):
+    list_display = ('teleuser', 'category', 'topic_id', 'created_at')
+    search_fields = ('teleuser__first_name', 'teleuser__nickname', 'teleuser__telegram_id', 'category')

--- a/main/migrations/0016_per_driver_routing.py
+++ b/main/migrations/0016_per_driver_routing.py
@@ -1,0 +1,70 @@
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('main', '0015_update_bot_schema'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='teleuser',
+            name='driver_group_id',
+            field=models.BigIntegerField(blank=True, help_text='Group where driver participates', null=True),
+        ),
+        migrations.AddField(
+            model_name='teleuser',
+            name='manager_group_id',
+            field=models.BigIntegerField(blank=True, help_text='Group where only managers participate', null=True),
+        ),
+        migrations.CreateModel(
+            name='TopicMap',
+            fields=[
+                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('category', models.CharField(max_length=100)),
+                ('topic_id', models.BigIntegerField()),
+                ('created_at', models.DateTimeField(auto_now_add=True)),
+                ('teleuser', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='main.teleuser')),
+            ],
+            options={
+                'unique_together': {('teleuser', 'category')},
+            },
+        ),
+        migrations.AddField(
+            model_name='messagelog',
+            name='category_name',
+            field=models.CharField(blank=True, max_length=200, null=True),
+        ),
+        migrations.AddField(
+            model_name='messagelog',
+            name='driver_group_id',
+            field=models.BigIntegerField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name='messagelog',
+            name='manager_group_id',
+            field=models.BigIntegerField(blank=True, null=True),
+        ),
+        migrations.AlterField(
+            model_name='messagelog',
+            name='category',
+            field=models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, to='main.category'),
+        ),
+        migrations.AlterField(
+            model_name='messagelog',
+            name='company',
+            field=models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.CASCADE, to='main.company'),
+        ),
+        migrations.AlterField(
+            model_name='messagelog',
+            name='from_group_id',
+            field=models.BigIntegerField(blank=True, null=True),
+        ),
+        migrations.AlterField(
+            model_name='messagelog',
+            name='to_group_id',
+            field=models.BigIntegerField(blank=True, null=True),
+        ),
+    ]

--- a/main/models.py
+++ b/main/models.py
@@ -17,9 +17,31 @@ class TeleUser(models.Model):
     nickname = models.CharField(max_length=100, blank=True, null=True)
     truck_number = models.CharField(max_length=100, blank=True, null=True)
     company = models.ForeignKey(Company, null=True, blank=True, on_delete=models.SET_NULL)
+    driver_group_id = models.BigIntegerField(
+        null=True,
+        blank=True,
+        help_text="Group where driver participates"
+    )
+    manager_group_id = models.BigIntegerField(
+        null=True,
+        blank=True,
+        help_text="Group where only managers participate"
+    )
 
     def __str__(self):
-        return f"{self.first_name} ({self.nickname})"
+        name = self.first_name or "Driver"
+        nickname_part = f" ({self.nickname})" if self.nickname else ""
+        return f"{name}{nickname_part} ({self.telegram_id})"
+
+
+class TopicMap(models.Model):
+    teleuser = models.ForeignKey(TeleUser, on_delete=models.CASCADE)
+    category = models.CharField(max_length=100)
+    topic_id = models.BigIntegerField()
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        unique_together = ('teleuser', 'category')
 
 
 class TimeOff(models.Model):
@@ -93,10 +115,13 @@ class BotConfig(models.Model):
 
 class MessageLog(models.Model):
     teleuser = models.ForeignKey(TeleUser, on_delete=models.CASCADE)
-    company = models.ForeignKey(Company, on_delete=models.CASCADE)
-    category = models.ForeignKey(Category, on_delete=models.SET_NULL, null=True)
-    from_group_id = models.BigIntegerField()
-    to_group_id = models.BigIntegerField()
+    company = models.ForeignKey(Company, on_delete=models.CASCADE, null=True, blank=True)
+    category = models.ForeignKey(Category, on_delete=models.SET_NULL, null=True, blank=True)
+    category_name = models.CharField(max_length=200, blank=True, null=True)
+    from_group_id = models.BigIntegerField(null=True, blank=True)
+    to_group_id = models.BigIntegerField(null=True, blank=True)
+    driver_group_id = models.BigIntegerField(null=True, blank=True)
+    manager_group_id = models.BigIntegerField(null=True, blank=True)
     topic_id = models.BigIntegerField(null=True, blank=True)
     content_text = models.TextField(blank=True, null=True)
     content_photo = models.TextField(blank=True, null=True)


### PR DESCRIPTION
## Summary
- add per-driver group fields and topic mapping to support manager forum routing
- forward driver messages through a new helper that creates and reuses manager topics while logging payloads
- expose the new data in the admin and ship the accompanying migration

## Testing
- not run (Django is not installed in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e6457f9300832882f36393ac894ee2