### PR TITLE
Implement per-driver topic routing for manager groups

### DIFF
--- a/main/admin.py
+++ b/main/admin.py
@@ -66,4 +66,4 @@ class MessageLogAdmin(admin.ModelAdmin):
 @admin.register(TopicMap)
 class TopicMapAdmin(admin.ModelAdmin):
     list_display = ('teleuser', 'category', 'topic_id', 'created_at')
-    search_fields = ('teleuser__first_name', 'teleuser__nickname', 'teleuser__telegram_id', 'category')
+    search_fields = ('teleuser__first_name', 'teleuser__nickname', 'teleuser__telegram_id', 'category__name')

--- a/main/migrations/0017_category_topicmap_update.py
+++ b/main/migrations/0017_category_topicmap_update.py
@@ -1,0 +1,74 @@
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+def copy_topicmap_category_forward(apps, schema_editor):
+    TopicMap = apps.get_model('main', 'TopicMap')
+    Category = apps.get_model('main', 'Category')
+    for topic_map in TopicMap.objects.all():
+        name = getattr(topic_map, 'category_name', None)
+        if not name:
+            name = 'General'
+        category, _ = Category.objects.get_or_create(name=name)
+        topic_map.category = category
+        topic_map.save(update_fields=['category'])
+
+
+def copy_topicmap_category_backward(apps, schema_editor):
+    TopicMap = apps.get_model('main', 'TopicMap')
+    for topic_map in TopicMap.objects.select_related('category'):
+        topic_map.category_name = topic_map.category.name if topic_map.category else None
+        topic_map.save(update_fields=['category_name'])
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('main', '0016_per_driver_routing'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='category',
+            name='description',
+            field=models.TextField(blank=True, null=True),
+        ),
+        migrations.AlterField(
+            model_name='category',
+            name='company',
+            field=models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.CASCADE, to='main.company'),
+        ),
+        migrations.AlterField(
+            model_name='category',
+            name='name',
+            field=models.CharField(max_length=100, unique=True),
+        ),
+        migrations.AlterUniqueTogether(
+            name='topicmap',
+            unique_together=set(),
+        ),
+        migrations.RenameField(
+            model_name='topicmap',
+            old_name='category',
+            new_name='category_name',
+        ),
+        migrations.AddField(
+            model_name='topicmap',
+            name='category',
+            field=models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.CASCADE, to='main.category'),
+        ),
+        migrations.RunPython(copy_topicmap_category_forward, copy_topicmap_category_backward),
+        migrations.AlterField(
+            model_name='topicmap',
+            name='category',
+            field=models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='main.category'),
+        ),
+        migrations.RemoveField(
+            model_name='topicmap',
+            name='category_name',
+        ),
+        migrations.AlterUniqueTogether(
+            name='topicmap',
+            unique_together={('teleuser', 'category')},
+        ),
+    ]

--- a/main/models.py
+++ b/main/models.py
@@ -36,7 +36,7 @@ class TeleUser(models.Model):
 
 class TopicMap(models.Model):
     teleuser = models.ForeignKey(TeleUser, on_delete=models.CASCADE)
-    category = models.CharField(max_length=100)
+    category = models.ForeignKey('Category', on_delete=models.CASCADE)
     topic_id = models.BigIntegerField()
     created_at = models.DateTimeField(auto_now_add=True)
 
@@ -62,14 +62,15 @@ class CompanyBoundQuerySet(models.QuerySet):
 
 
 class Category(models.Model):
-    name = models.CharField(max_length=200, unique=True)
+    name = models.CharField(max_length=100, unique=True)
+    description = models.TextField(blank=True, null=True)
     responsible_topic_id = models.CharField(
         max_length=50,
         blank=True,
         null=True,
         help_text="Укажите ID топика (message_thread_id) в форуме"
     )
-    company = models.ForeignKey(Company, on_delete=models.CASCADE)
+    company = models.ForeignKey(Company, on_delete=models.CASCADE, null=True, blank=True)
 
     objects = CompanyBoundQuerySet.as_manager()
 


### PR DESCRIPTION
## Summary
- update the Category and TopicMap models to support per-driver category topics and add a migration that preserves existing mappings
- add a reusable helper that forwards driver messages to their manager group topics and logs each message
- adjust question handling and time-off flows to rely on each teleuser’s manager group instead of company-level routing

## Testing
- not run (Django is not installed in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e65f93929483288832263cf5a777e1