### PR TITLE
Improve manager topic storage and admin views

### DIFF
--- a/main/admin.py
+++ b/main/admin.py
@@ -1,5 +1,17 @@
 from django.contrib import admin
-from .models import Company, TeleUser, TimeOff, Category, Question, UserQuestion, BotConfig, MessageLog, TopicMap
+from .models import (
+    Company,
+    TeleUser,
+    TimeOff,
+    Category,
+    Question,
+    UserQuestion,
+    BotConfig,
+    MessageLog,
+    TopicMap,
+    ManagerGroup,
+    ManagerTopic,
+)
 
 admin.site.site_header = "Sayram Express LLC"
 admin.site.site_title = "Sayram Express LLC Admin Page"
@@ -67,3 +79,18 @@ class MessageLogAdmin(admin.ModelAdmin):
 class TopicMapAdmin(admin.ModelAdmin):
     list_display = ('teleuser', 'category', 'topic_id', 'created_at')
     search_fields = ('teleuser__first_name', 'teleuser__nickname', 'teleuser__telegram_id', 'category__name')
+
+
+@admin.register(ManagerTopic)
+class ManagerTopicAdmin(admin.ModelAdmin):
+    list_display = ('category_name', 'thread_id', 'topic_name', 'created_at')
+    list_filter = ('category_name',)
+    search_fields = ('category_name', 'topic_name', 'thread_id')
+    raw_id_fields = ('category',)
+
+
+@admin.register(ManagerGroup)
+class ManagerGroupAdmin(admin.ModelAdmin):
+    list_display = ('group_id', 'created_at')
+    search_fields = ('group_id',)
+    filter_horizontal = ('topics',)


### PR DESCRIPTION
## Summary
- add a compatibility alias on stored forum topic info so helpers can read the recorded thread id
- reuse stored manager topic mappings when routing driver messages before falling back to Telegram lookups
- register manager group and topic models in the Django admin for visibility

## Testing
- python manage.py check *(fails: Django is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f26c65be4c83288940fb1fd7a4ec0f