### PR TITLE
Link manager topics to manager groups to prevent duplicates

### DIFF
--- a/main/migrations/0020_manager_topic_group_fk.py
+++ b/main/migrations/0020_manager_topic_group_fk.py
@@ -1,0 +1,75 @@
+# Generated manually because Django is unavailable in the execution environment.
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+def migrate_group_relations(apps, schema_editor):
+    ManagerTopic = apps.get_model("main", "ManagerTopic")
+
+    for topic in ManagerTopic.objects.all():
+        group = topic.manager_groups.order_by("id").first()
+        if group is None:
+            continue
+        topic.group_id = group.id
+        topic.save(update_fields=["group"])
+
+
+def reverse_migrate_group_relations(apps, schema_editor):
+    ManagerTopic = apps.get_model("main", "ManagerTopic")
+    ManagerGroup = apps.get_model("main", "ManagerGroup")
+
+    for topic in ManagerTopic.objects.all():
+        if topic.group_id:
+            try:
+                group = ManagerGroup.objects.get(pk=topic.group_id)
+            except ManagerGroup.DoesNotExist:
+                group = None
+            else:
+                group.topics.add(topic)
+        topic.group = None
+        topic.save(update_fields=["group"])
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("main", "0019_manager_group_topics"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="managertopic",
+            name="group",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name="topics",
+                to="main.managergroup",
+            ),
+        ),
+        migrations.RunPython(
+            migrate_group_relations,
+            reverse_code=reverse_migrate_group_relations,
+        ),
+        migrations.AlterField(
+            model_name="managertopic",
+            name="group",
+            field=models.ForeignKey(
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name="topics",
+                to="main.managergroup",
+            ),
+        ),
+        migrations.RemoveField(
+            model_name="managergroup",
+            name="topics",
+        ),
+        migrations.AlterUniqueTogether(
+            name="managertopic",
+            unique_together={
+                ("group", "category_name"),
+                ("group", "thread_id"),
+            },
+        ),
+    ]

--- a/main/models.py
+++ b/main/models.py
@@ -133,7 +133,20 @@ class MessageLog(models.Model):
         return f"MessageLog #{self.pk} from {self.teleuser}"
 
 
+class ManagerGroup(models.Model):
+    group_id = models.BigIntegerField(unique=True)
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    def __str__(self):
+        return f"ManagerGroup {self.group_id}"
+
+
 class ManagerTopic(models.Model):
+    group = models.ForeignKey(
+        ManagerGroup,
+        on_delete=models.CASCADE,
+        related_name="topics",
+    )
     category = models.ForeignKey(
         Category,
         on_delete=models.SET_NULL,
@@ -147,17 +160,11 @@ class ManagerTopic(models.Model):
     created_at = models.DateTimeField(auto_now_add=True)
 
     class Meta:
-        unique_together = ("category_name", "thread_id")
+        unique_together = (
+            ("group", "category_name"),
+            ("group", "thread_id"),
+        )
 
     def __str__(self):
         display_name = self.topic_name or self.category_name or "Topic"
         return f"{display_name} ({self.thread_id})"
-
-
-class ManagerGroup(models.Model):
-    group_id = models.BigIntegerField(unique=True)
-    topics = models.ManyToManyField(ManagerTopic, related_name="manager_groups", blank=True)
-    created_at = models.DateTimeField(auto_now_add=True)
-
-    def __str__(self):
-        return f"ManagerGroup {self.group_id}"


### PR DESCRIPTION
## Summary
- add a direct manager group foreign key on ManagerTopic and enforce per-group uniqueness
- update the bot topic synchronisation helpers to rely on the per-group relation to skip duplicate topics
- provide a migration that migrates existing many-to-many data into the new foreign key and drops the join table

## Testing
- python manage.py makemigrations *(fails: Django is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f270a746308328b46577099214db91