### PR TITLE
Refactor manager topic sync to avoid duplicate threads

### DIFF
--- a/main/admin.py
+++ b/main/admin.py
@@ -83,14 +83,13 @@ class TopicMapAdmin(admin.ModelAdmin):
 
 @admin.register(ManagerTopic)
 class ManagerTopicAdmin(admin.ModelAdmin):
-    list_display = ('category_name', 'thread_id', 'topic_name', 'created_at')
-    list_filter = ('category_name',)
-    search_fields = ('category_name', 'topic_name', 'thread_id')
-    raw_id_fields = ('category',)
+    list_display = ('group', 'category_name', 'topic_name', 'thread_id', 'created_at')
+    list_filter = ('group', 'category_name')
+    search_fields = ('category_name', 'topic_name', 'thread_id', 'group__group_id')
+    raw_id_fields = ('category', 'group')
 
 
 @admin.register(ManagerGroup)
 class ManagerGroupAdmin(admin.ModelAdmin):
     list_display = ('group_id', 'created_at')
     search_fields = ('group_id',)
-    filter_horizontal = ('topics',)

--- a/main/migrations/0021_manager_topic_constraints.py
+++ b/main/migrations/0021_manager_topic_constraints.py
@@ -1,0 +1,38 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("main", "0020_manager_topic_group_fk"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="managergroup",
+            name="group_id",
+            field=models.BigIntegerField(db_index=True, unique=True),
+        ),
+        migrations.AlterField(
+            model_name="managertopic",
+            name="topic_name",
+            field=models.CharField(max_length=100),
+        ),
+        migrations.AlterField(
+            model_name="managertopic",
+            name="thread_id",
+            field=models.BigIntegerField(db_index=True),
+        ),
+        migrations.AlterUniqueTogether(
+            name="managertopic",
+            unique_together={("group", "category_name")},
+        ),
+        migrations.AddIndex(
+            model_name="managertopic",
+            index=models.Index(fields=["group", "category_name"], name="main_mgrtopic_group_cat_idx"),
+        ),
+        migrations.AddIndex(
+            model_name="managertopic",
+            index=models.Index(fields=["group", "topic_name"], name="main_mgrtopic_group_topic_idx"),
+        ),
+    ]


### PR DESCRIPTION
## Summary
- normalize manager topic metadata in the Django models and add supporting indexes/migration
- refactor /run and /sync handlers to rely on DB state, probe Telegram threads, and avoid duplicate topic creation
- refresh admin configuration for manager topics to surface key fields

## Testing
- python manage.py makemigrations *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68f366c0a5988328a39dc2cc5d5428fd